### PR TITLE
Seperate views animated

### DIFF
--- a/SwiftLearning/Settings.swift
+++ b/SwiftLearning/Settings.swift
@@ -1,8 +1,0 @@
-//
-//  Settings.swift
-//  SwiftLearning
-//
-//  Created by Jacob Winter on 4/4/25.
-//
-
-import Foundation

--- a/SwiftLearning/Settings.swift
+++ b/SwiftLearning/Settings.swift
@@ -1,0 +1,8 @@
+//
+//  Settings.swift
+//  SwiftLearning
+//
+//  Created by Jacob Winter on 4/4/25.
+//
+
+import Foundation

--- a/SwiftLearning/SwiftLearning/ClassifyScreen.swift
+++ b/SwiftLearning/SwiftLearning/ClassifyScreen.swift
@@ -1,0 +1,8 @@
+//
+//  ClassifyScreen.swift
+//  SwiftLearning
+//
+//  Created by Jacob Winter on 4/4/25.
+//
+
+import Foundation

--- a/SwiftLearning/SwiftLearning/ClassifyScreen.swift
+++ b/SwiftLearning/SwiftLearning/ClassifyScreen.swift
@@ -1,8 +1,8 @@
-//
-//  ClassifyScreen.swift
-//  SwiftLearning
-//
-//  Created by Jacob Winter on 4/4/25.
-//
+import UIKit
+import ARKit
+import RealityKit
+import Vision
 
-import Foundation
+class ClassifyScreen: VNClassifyImageRequest {
+    
+}

--- a/SwiftLearning/SwiftLearning/ContentView.swift
+++ b/SwiftLearning/SwiftLearning/ContentView.swift
@@ -14,7 +14,6 @@ struct ContentView : View {
             self.arActive.toggle()
             
             withAnimation(.easeInOut(duration: 0.5)) {
-                
                 self.offsetX = 0
             }
         }

--- a/SwiftLearning/SwiftLearning/FactView.swift
+++ b/SwiftLearning/SwiftLearning/FactView.swift
@@ -1,8 +1,24 @@
-//
-//  FactView.swift
-//  SwiftLearning
-//
-//  Created by Jacob Winter on 4/2/25.
-//
+import SwiftUI
 
-import Foundation
+struct FactViewContainer : View {
+    var body: some View {
+        VStack {
+            Text("VStack")
+                .font(.largeTitle)
+            
+            HStack {
+                Text("HStack")
+                    .contentShape(Rectangle())
+                    .padding()
+                
+                Rectangle()
+                    .frame(height: 200)
+                    .foregroundColor(.red)
+            }
+        }
+        
+        .background(Rectangle().fill(Color.mint))
+        .frame(alignment: .top)
+    }
+}
+

--- a/SwiftLearning/SwiftLearning/FactView.swift
+++ b/SwiftLearning/SwiftLearning/FactView.swift
@@ -6,7 +6,7 @@ struct FactViewContainer : View {
             Text("VStack")
                 .font(.largeTitle)
             
-            HStack {
+            HStack { // horizontal stack
                 Text("HStack")
                     .contentShape(Rectangle())
                     .padding()
@@ -22,3 +22,6 @@ struct FactViewContainer : View {
     }
 }
 
+#Preview {
+    FactViewContainer()
+}

--- a/SwiftLearning/SwiftLearning/FactView.swift
+++ b/SwiftLearning/SwiftLearning/FactView.swift
@@ -1,0 +1,8 @@
+//
+//  FactView.swift
+//  SwiftLearning
+//
+//  Created by Jacob Winter on 4/2/25.
+//
+
+import Foundation

--- a/SwiftLearning/SwiftLearning/FeatureReader.swift
+++ b/SwiftLearning/SwiftLearning/FeatureReader.swift
@@ -1,6 +1,6 @@
 //
 // creates a reader that scans the AR view
-// and can be read by 
+// gathers all the necessary features for the AI call
 //
 
 import Foundation

--- a/SwiftLearning/SwiftLearning/FeatureReader.swift
+++ b/SwiftLearning/SwiftLearning/FeatureReader.swift
@@ -1,0 +1,6 @@
+//
+// creates a reader that scans the AR view
+// and can be read by 
+//
+
+import Foundation

--- a/SwiftLearning/SwiftLearning/Settings.swift
+++ b/SwiftLearning/SwiftLearning/Settings.swift
@@ -1,8 +1,13 @@
-//
-//  Settings.swift
-//  SwiftLearning
-//
-//  Created by Jacob Winter on 4/4/25.
-//
+import SwiftUI
 
-import Foundation
+struct SettingsContainer: View {
+    var body: some View {
+        Rectangle()
+            .fill(Color.blue)
+    }
+}
+
+
+#Preview {
+    SettingsContainer()
+}

--- a/SwiftLearning/SwiftLearning/Settings.swift
+++ b/SwiftLearning/SwiftLearning/Settings.swift
@@ -1,0 +1,8 @@
+//
+//  Settings.swift
+//  SwiftLearning
+//
+//  Created by Jacob Winter on 4/4/25.
+//
+
+import Foundation

--- a/SwiftLearning/SwiftLearning/WorldView.swift
+++ b/SwiftLearning/SwiftLearning/WorldView.swift
@@ -1,25 +1,60 @@
 import SwiftUI
 import RealityKit
+import ARKit
 
-struct ARViewContainer: View {
-    var body: some View {
-        RealityView { content in
-            
-            // Create a cube model
-            let model = Entity()
-            let mesh = MeshResource.generateBox(size: 0.1, cornerRadius: 0.005)
-            let material = SimpleMaterial(color: .blue, roughness: 0.15, isMetallic: true)
-            model.components.set(ModelComponent(mesh: mesh, materials: [material]))
-            model.position = [0, 0.05, 0]
-            
-            // Create horizontal plane anchor for the content
-            let anchor = AnchorEntity(.plane(.horizontal, classification: .any, minimumBounds: SIMD2<Float>(0.2, 0.2)))
-            anchor.addChild(model)
-            
-            // Add the horizontal plane anchor to the scene
-            content.add(anchor)
-            
-            content.camera = .spatialTracking
+class WorldViewController: UIViewController {
+    
+    var arView: ARView!
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        arView = ARView(frame: view.bounds)
+        arView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(arView)
+        
+        let configuration = ARWorldTrackingConfiguration()
+        arView.session.run(configuration)
+        
+        // Create a cube model
+        let model = Entity()
+        let mesh = MeshResource.generateBox(size: 0.1, cornerRadius: 0.005)
+        let material = SimpleMaterial(color: .blue, roughness: 0.15, isMetallic: true)
+        model.components.set(ModelComponent(mesh: mesh, materials: [material]))
+        model.position = [0, 0.05, 0]
+        
+        // Create horizontal plane anchor for the content
+        let anchor = AnchorEntity(.plane(.horizontal, classification: .any, minimumBounds: SIMD2<Float>(0.2, 0.2)))
+        anchor.addChild(model)
+        
+        arView.scene.addAnchor(anchor)
+    }
+    
+    func pauseSession() {
+        arView.session.pause()
+        print("AR Session Paused")
+    }
+    
+    func resumeSession() {
+        let configuration = ARWorldTrackingConfiguration()
+        arView.session.run(configuration, options: [])
+        print("AR Session Resumed")
+    }
+}
+
+struct WorldViewContainer: UIViewControllerRepresentable {
+    @Binding var isActive: Bool
+    let controller = WorldViewController()
+    
+    func makeUIViewController(context: Context) -> WorldViewController {
+        return controller
+    }
+    
+    func updateUIViewController(_ uiViewController: WorldViewController, context: Context) {
+        if isActive {
+            uiViewController.resumeSession()
+        } else {
+            uiViewController.pauseSession()
         }
     }
 }

--- a/SwiftLearning/SwiftLearning/WorldView.swift
+++ b/SwiftLearning/SwiftLearning/WorldView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+import RealityKit
+
+struct ARViewContainer: View {
+    var body: some View {
+        RealityView { content in
+            
+            // Create a cube model
+            let model = Entity()
+            let mesh = MeshResource.generateBox(size: 0.1, cornerRadius: 0.005)
+            let material = SimpleMaterial(color: .blue, roughness: 0.15, isMetallic: true)
+            model.components.set(ModelComponent(mesh: mesh, materials: [material]))
+            model.position = [0, 0.05, 0]
+            
+            // Create horizontal plane anchor for the content
+            let anchor = AnchorEntity(.plane(.horizontal, classification: .any, minimumBounds: SIMD2<Float>(0.2, 0.2)))
+            anchor.addChild(model)
+            
+            // Add the horizontal plane anchor to the scene
+            content.add(anchor)
+            
+            content.camera = .spatialTracking
+        }
+    }
+}

--- a/SwiftLearning/SwiftLearning/WorldView.swift
+++ b/SwiftLearning/SwiftLearning/WorldView.swift
@@ -1,10 +1,16 @@
 import SwiftUI
 import RealityKit
 import ARKit
+import Vision
 
-class WorldViewController: UIViewController {
+class WorldViewController: UIViewController, ARSessionDelegate {
     
     var arView: ARView!
+    var visionQueue = DispatchQueue(label: "com.example.visionQueue")
+    var request: VNClassifyImageRequest!
+    
+    var lastClassificationDate = Date(timeIntervalSince1970: 0) // placeholder for how the image recognition is triggered
+    let classificationInterval: TimeInterval = 3 // sends frame every X seconds
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -14,20 +20,69 @@ class WorldViewController: UIViewController {
         view.addSubview(arView)
         
         let configuration = ARWorldTrackingConfiguration()
+        arView.session.delegate = self
         arView.session.run(configuration)
         
+        setupVision()
+        
+        // remove later
+        arView.debugOptions = [.showAnchorOrigins, .showAnchorGeometry]
+        
+        let anchor = createAnchor()
+        arView.scene.addAnchor(anchor)
+    }
+    
+    func session(_ session: ARSession, didUpdate frame: ARFrame) {
+        let now = Date()
+        if now.timeIntervalSince(lastClassificationDate) > classificationInterval {
+            lastClassificationDate = now
+            classifyCurrentFrame(pixelBuffer: frame.capturedImage)
+        }
+    }
+        
+    
+    func classifyCurrentFrame(pixelBuffer: CVPixelBuffer) {
+        let handler = VNImageRequestHandler(cvPixelBuffer: pixelBuffer, orientation: .up, options: [:])
+        visionQueue.async {
+            do {
+                try handler.perform([self.request])
+            } catch {
+                print("Vision error: \(error)")
+            }
+        }
+    }
+    
+    func setupVision() {
+        request = VNClassifyImageRequest { request, error in
+            guard let results = request.results as? [VNClassificationObservation] else { return }
+            
+            // confidence above 40% is recognized
+            if let topResult = results.first, topResult.confidence > 0.4 {
+                DispatchQueue.main.async {
+                    self.handleClassification(result: topResult)
+                }
+            }
+        }
+    }
+    
+    func handleClassification(result: VNClassificationObservation) {
+        print("Found: " + result.identifier, result.confidence)
+    }
+    
+    func createAnchor () -> AnchorEntity {
         // Create a cube model
         let model = Entity()
-        let mesh = MeshResource.generateBox(size: 0.1, cornerRadius: 0.005)
+        let mesh = MeshResource.generateBox(size: 0.1, cornerRadius: 0.009)
         let material = SimpleMaterial(color: .blue, roughness: 0.15, isMetallic: true)
         model.components.set(ModelComponent(mesh: mesh, materials: [material]))
-        model.position = [0, 0.05, 0]
+        model.position = [-0.5, -0.5, 0]
         
         // Create horizontal plane anchor for the content
-        let anchor = AnchorEntity(.plane(.horizontal, classification: .any, minimumBounds: SIMD2<Float>(0.2, 0.2)))
+        //let anchor = AnchorEntity(.plane(.horizontal, classification: .any, minimumBounds: SIMD2<Float>(0.2, 0.2)))
+        let anchor = AnchorEntity(world: SIMD3<Float>(0, 0, 0))
         anchor.addChild(model)
         
-        arView.scene.addAnchor(anchor)
+        return anchor
     }
     
     func pauseSession() {
@@ -40,6 +95,16 @@ class WorldViewController: UIViewController {
         arView.session.run(configuration, options: [])
         print("AR Session Resumed")
     }
+    
+    // image recognition and tap used to get what the user is looking at
+    // then combine that data with position data for use later
+    // send that packet to another function that will use the features
+    // and return a trext description
+    // another function calls that function and uses the description, position, and screenshot to create
+    //  - a Fact© in the facts page
+    //  - a Sign© in the AR view with the text description
+    //  - a window in the AR view that shows related facts
+
 }
 
 struct WorldViewContainer: UIViewControllerRepresentable {


### PR DESCRIPTION
Addresses #16 and #7

**What was changed**

- The views were moved to different files
- `RealityView` component switched to directly calling a new instance of the ARView class
- Added a controller for the new `ARView` and a container for the controller
- Added an offset animation to switching between views. 

**Why was it changed**

Currently the views were all in one file, which was very hard to read. Switching between views was slow and clunky, so instead of unloading the `RealityView` component I opted to pause the ARsession to completely erase the lag.

**How was this changed**

We were using the `RealityView` swiftUI element, which didn't allow us to control the session at a low enough level. So I switched to `ARView()` to initialize the AR experience, added a container and a controller for it, and created a binded state variable passed from `ContentView` to `WorldViewContainer` that automatically pauses/unpauses the ARsession when the `arActive` boolean is toggled in `ContentView`. This works because of `WorldViewContainer`'s superclass `UIViewControllerRepresentable`

